### PR TITLE
Update draft-toutain-schc-access-control-00.md

### DIFF
--- a/draft-toutain-schc-access-control-00.md
+++ b/draft-toutain-schc-access-control-00.md
@@ -97,7 +97,7 @@ A Device RM under control of an attacker sends some management messages to modif
 For example ... TBD
 
 2. Management messages aiming at changing rules where the length of the residue changes:
-   * There can be a risk of desyncronising rules between the core and the compromised device.
+   * There can be a risk of desynchronizing rules between the core and the compromised device.
    * The attack is limited to a single end-point (the device) since it does not have the rigths to change core-level rules.
 
 As SCHC rules are defined for a specific traffic. An example of this can be an attacker changing en element of the rule (for instance, the dev UDP port number) and therefore no rule matches the traffic. Therefore, the core may be saturated by no-compressed messages.

--- a/draft-toutain-schc-access-control-00.md
+++ b/draft-toutain-schc-access-control-00.md
@@ -90,17 +90,30 @@ The attack scenarios considered below are limited to the rule management layer, 
 A Device RM under control of an attacker sends some management messages to modify the SCHC rules in the core in order to direct the traffic to another application. The impact of this attack is different depending on the original rule:
 
 1. Rules containing exlusively the pair MA -- CDA : [ignore -- not-send] or rules such as no-compress or no-frarmentation: 
- * There is no risk of information lost. 
- * There is a risk of DoS-type attack as it can flood empty packets that pass at the core level.
- * The attack is limited to a single end-point (the device) since it does not have the rigths to change core-level rules.
+   * There is no risk of information lost. 
+   * There is a risk of DoS-type attack as it can flood empty packets that pass at the core level.
+   * The attack is limited to a single end-point (the device) since it does not have the rigths to change core-level rules.
 
-2. 
+For instance ... TBD
+
+2. Management messages aiming at changing rules where the length of the residue changes:
+   * There can be a risk of desyncronising rules between the core and the compromised device.
+   * The attack is limited to a single end-point (the device) since it does not have the rigths to change core-level rules.
+
+As SCHC rules are defined for a specific traffic. An example of this can be an attacker changing en element of the rule (for instance, the dev UDP port number) and therefore no rule matches the traffic. Therefore, the core may be saturated by no-compressed messages.
+
+# Scenario 2: Compromised Core
+
+A Core RM under control of an attacker sends some management messages to modify the SCHC rules in the device in order to deleate devices' data. 
+In such scenario, the attacker will try to inject destructive rules.
+
+The main characteristic of these rules is that the combination of MA -- CA reduces the size of the residue, which has in turn made it more attractive since it increases the rate of compression.
+
+The impact of this attack could be:
+  * Lost of devices' information if nothing is done to preeempt a compromised core to change such a rule.
 
 
-
-An example of this can be SCHC rules are defined for a specific traffic. 
-
-An attacker changes en element (for instance, the dev UDP port number) and therefore no rule matches the traffic, the link may be saturated by no-compressed messages.
+An example of this atack could be ... TBD
 
 
 # YANG Access Control

--- a/draft-toutain-schc-access-control-00.md
+++ b/draft-toutain-schc-access-control-00.md
@@ -70,9 +70,9 @@ Figure {{Fig-archi-overview}} focuses on the management part of the SCHC archite
 When a management request arrives on a SCHC end-point, the identity of the requester must be 
 checked:
 
- * this can be implicit, for instance a LPWAN device receives it from the SCHC core instance. Authentication 
+ * this can be implicit, for example a LPWAN device receives it from the SCHC core instance. Authentication 
  is done at Layer 2.
- * this can be a L2 address. In a LoRaWAN network, for instance the DevEUI allows the SCHC core to identify the device.
+ * this can be a L2 address. In a LoRaWAN network, for example the DevEUI allows the SCHC core to identify the device.
  * IP addresses may also be used as well as cryptographic keys.
 
 The identification of the requester allows to retrieve the associated Set of Rules. These rules are enriched with access control information that will be defined in this document. If the Set of Rules does not contains any access control information, the management is not allowed to modify the Rules content.

--- a/draft-toutain-schc-access-control-00.md
+++ b/draft-toutain-schc-access-control-00.md
@@ -79,7 +79,7 @@ The identification of the requester allows to retrieve the associated Set of Rul
 
 # Threat Model
 
-The Rule Manager (RM) is in charge of applying changes to the rules database when a management request arrives to a SCHC end-point. It is assumed that the these changes can only be effectivelly applied when it is certain that all end-points of an instance have made the change. This means that in all cases a peer of peers in an intance always share the same Set of Rules.
+The Rule Manager (RM) is in charge of applying changes to the rules database when a management request arrives to a SCHC end-point. It is assumed that  these changes can only be effectivelly applied when it is certain that all end-points of an instance have made the change. This means that in all cases a peer of peers in an intance always share the same Set of Rules.
 
 The selection of a rule to be applied in a certain end-point when a packet arrives is done by selecting the rule offering the smallest SCHC packet after compression.
 

--- a/draft-toutain-schc-access-control-00.md
+++ b/draft-toutain-schc-access-control-00.md
@@ -79,7 +79,7 @@ The identification of the requester allows to retrieve the associated Set of Rul
 
 # Threat Model
 
-The Rule Manager (RM) is in charge of applying changes to the rules database when a management request arrives to a SCHC end pont. It is assumed that the these changes can only be effectivelly applied when it is certain that all end-points of an instance have made the change. This means that in all cases a peer of peers in an intance always share the same Set of Rules.
+The Rule Manager (RM) is in charge of applying changes to the rules database when a management request arrives to a SCHC end-point. It is assumed that the these changes can only be effectivelly applied when it is certain that all end-points of an instance have made the change. This means that in all cases a peer of peers in an intance always share the same Set of Rules.
 
 The selection of a rule to be applied in a certain end-point when a packet arrives is done by selecting the rule offering the smallest SCHC packet after compression.
 
@@ -94,7 +94,7 @@ A Device RM under control of an attacker sends some management messages to modif
    * There is a risk of DoS-type attack as it can flood empty packets that pass at the core level.
    * The attack is limited to a single end-point (the device) since it does not have the rigths to change core-level rules.
 
-For instance ... TBD
+For example ... TBD
 
 2. Management messages aiming at changing rules where the length of the residue changes:
    * There can be a risk of desyncronising rules between the core and the compromised device.


### PR DESCRIPTION
- Adding some attack senarios
- Changing end-point instead of entities so that is the same terminology as in the archi draft. Deleating "core instance" -- I think saying core is enough. The archi draft says: "A
   session called a SCHC Instance is established and SCHC maintains a state and timers associated to that Instance."
-